### PR TITLE
Update composer.json To Make Neuralyzer Dev-Only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "authors": [
     {
-      "name": "Sugar Team, The New York Times",
+      "name": "Customer Care Technology Team, The New York Times",
       "email": "nytcsdev@nytimes.com",
       "role": "Fork Development Team"
     },
@@ -33,7 +33,6 @@
     "guzzle/guzzle": "~3.9",
     "inetprocess/libinventoryclient": "^1.0",
     "inetprocess/libsugarcrm": "^1.2",
-    "inetprocess/neuralyzer": "~0.6",
     "jms/serializer": "~0.16",
     "padraic/phar-updater": "^1.0",
     "symfony/config": "^2.8",
@@ -50,6 +49,7 @@
   "require-dev": {
     "phpunit/phpunit": "~4",
     "phpunit/dbunit": "~1.3",
+    "inetprocess/neuralyzer": "~0.6",
     "fabpot/php-cs-fixer": "^1.10"
   },
   "autoload": {


### PR DESCRIPTION
Make the neuralyzer library a dev-only library to mitigate minor security vulnerabilities in this library and the faker dependent library.

To test, update NYT composer.json file to the contents below, then in the app instance, run `composer update --no-dev`. The libraries `fzaninotto/faker` and `inetprocess/neuralyzer` should no longer be present. App repairing, which is why we need the `sugarcli-nyt` library on our deployed environments, should continue to work as expected.

```
{
  "name": "nytm/ecomm-core-oreo",
  "description": "SugarCRM Oreo",
  "type": "project",
  "license": "proprietary",
  "config": {
    "vendor-dir": "vendor",
    "notify-on-install": false,
    "discard-changes": true,
    "preferred-install": "dist",
    "use-include-path": false
  },
  "minimum-stability": "stable",
  "autoload": {
    "psr-4": {
      "NYT\\Sugar\\": [
        "./"
      ],
      "NYT\\SugarTest\\": [
        "../../tests"
      ],
      "NYT\\SugarUnitTest\\": [
        "../../tests/unit/sugarcrm/_nyt"
      ],
      "NYT\\SugarFunctionalTest\\": [
        "../../tests/functional/sugarcrm/_nyt"
      ],
      "NYT\\SugarAcceptanceTest\\": [
        "../../tests/acceptance/sugarcrm/_nyt"
      ]
    }
  },
  "repositories": [
    {
      "type": "vcs",
      "url": "https://github.com/nytm/ecomm-sugar-seg-client.git"
    },
    {
      "type": "vcs",
      "url": "https://github.com/nytm/sugarcli-nyt.git"
    }
  ],
  "require": {
    "psr/log": "1.0.0",
    "nategood/httpful": "0.2.20",
    "flow/jsonpath": "0.3.1",
    "php-di/php-di": "5.2.2",
    "doctrine/cache": "1.4",
    "monolog/monolog": "1.19.0",
    "aws/aws-sdk-php": "2.7.9",
    "fergusean/nusoap": "0.9.5",
    "league/iso3166": "1.0.1",
    "nyt/sugarcli-nyt": "dev-fix/SCRM-7404/neuralyzer_not_required",
    "nytm/ecomm-sugar-seg-client": "dev-master",
    "respect/validation": "1.1.10",
    "myclabs/php-enum": "1.5.0",
    "doctrine/dbal": "2.5.12"
  },
  "require-dev": {
    "phpunit/phpunit": "4.8.26",
    "codeception/codeception": "2.2.8",
    "fzaninotto/faker": "1.6.0",
    "allure-framework/allure-codeception": "1.2.2"
  }
}
```